### PR TITLE
解决若设置了contextPath无法进入管理界面的Bug

### DIFF
--- a/src/main/java/com/my/blog/website/interceptor/BaseInterceptor.java
+++ b/src/main/java/com/my/blog/website/interceptor/BaseInterceptor.java
@@ -42,6 +42,8 @@ public class BaseInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object o) throws Exception {
+        String contextPath = request.getContextPath();
+        // System.out.println(contextPath);
         String uri = request.getRequestURI();
 
         LOGGE.info("UserAgent: {}", request.getHeader(USER_AGENT));
@@ -58,7 +60,7 @@ public class BaseInterceptor implements HandlerInterceptor {
                 request.getSession().setAttribute(WebConst.LOGIN_SESSION_KEY, user);
             }
         }
-        if (uri.startsWith("/admin") && !uri.startsWith("/admin/login") && null == user) {
+        if (uri.startsWith(contextPath + "/admin") && !uri.startsWith(contextPath + "/admin/login") && null == user) {
             response.sendRedirect(request.getContextPath() + "/admin/login");
             return false;
         }


### PR DESCRIPTION
如果在application.properties中设置了server.context-path，在进入后台/admin时在BaseInterceptor中判断路径时会出现问题，这段代码正是解决这个问题的。